### PR TITLE
docs: 2026年7月のAgent Skills最新動向を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 |------------|--------------|
 | 💬 まず生成AIを触ってみたい（コードは書かない） | [非エンジニア向けクイックスタート](#-非エンジニア向けクイックスタート) |
 | 📋 業務シーン別に「使える例」を見たい | [シナリオ別ユースケース集](docs/use-cases.md) |
+| 🌐 2026年のSkills・MCP・GUI自動化をまとめて知りたい | [2026年7月版 Skills最新動向](docs/skills-ecosystem-2026.md) |
 | 📝 議事録・請求書・資料など事務作業を効率化したい | [事務・バックオフィス活用ガイド](docs/office-work.md) |
 | 💹 決算・経理・金融業務を効率化したい | [金融サービス向けスキル](docs/financial-services.md) |
 
@@ -86,6 +87,7 @@
 | **[シナリオ別ユースケース集](docs/use-cases.md)** | 役割・業務シーンから探す生成AIの実例カタログ（プロンプト例つき） | — |
 | **[事務・バックオフィス活用ガイド](docs/office-work.md)** | 議事録・請求書・レポート・スプレッドシート作成など、日々の事務作業を生成AIで効率化する実践ガイド | — |
 | **[金融サービス向けスキル](docs/financial-services.md)** | [anthropics/financial-services](https://github.com/anthropics/financial-services) 収録の金融・経理業務向けエージェント／スキル（決算照合・月次決算・KYC 等）の詳細解説 | 10 エージェント + 7 業務プラグイン |
+| **[2026年7月版 Skills最新動向](docs/skills-ecosystem-2026.md)** | Matt Pocock、Context7、Firecrawl、Vercel、Record & Replay、Computer Use / Browser Use の比較と使い分け | 6 テーマ |
 
 ---
 

--- a/docs/mattpocock-skills.md
+++ b/docs/mattpocock-skills.md
@@ -1,132 +1,153 @@
-# mattpocock/skills - 実務エンジニア向け Claude Code スキル集
+# mattpocock/skills - 実務エンジニア向け Agent Skills
 
-> [mattpocock/skills](https://github.com/mattpocock/skills) は、TypeScript 教育者として知られる **Matt Pocock** 氏が公開している、コーディングエージェント向けのスキル集です。「実際のエンジニアリング現場で AI エージェントを使うと起きる失敗」を防ぐことを目的に、**小さく・適応しやすく・組み合わせ可能**なスキルとして設計されています。
+> [mattpocock/skills](https://github.com/mattpocock/skills) は、TypeScript教育者として知られる **Matt Pocock** 氏が実務で使うAgent Skills集です。「vibe coding」ではなく、要件の認識合わせ、仕様化、TDD、デバッグ、設計、レビューといったソフトウェア開発の基本を、小さく組み合わせ可能なSkillとしてエージェントへ与えます。
 
 ## このリポジトリの特徴
 
-- **Claude Code をはじめとするコーディングエージェント**（Claude Agent SDK 互換）向け
-- 「AI 支援開発でよく起きる 4 つの失敗モード」を解決するという明確な設計思想
-- `skills` CLI（`npx skills`）でインストールでき、対象エージェントを選んで導入
-- **ユーザーが `/` で呼び出すスキル**と、**モデルが必要に応じて自動で呼び出すスキル**を区別
+- Claude Code、Codexなど、Agent Skills形式に対応するコーディングエージェントで利用できる
+- 巨大な開発フレームワークではなく、目的ごとに分割されたSkillを組み合わせる
+- **ユーザー呼び出し**のSkillが処理を編成し、**モデル呼び出し**のSkillが再利用可能な規律を提供する
+- `skills.sh` から編集可能なコピーとして導入する方法と、Claude Codeの管理プラグインとして購読する方法がある
 
 > [!NOTE]
-> [anthropics/skills](anthropics-skills.md) が「ドキュメント生成・デザインなど汎用タスク」中心なのに対し、こちらは **SDLC（開発プロセス）そのものを改善する**ワークフロー型スキルが中心です。
+> 2026年7月時点では、以前の `to-prd` / `to-issues` を中心とした構成から、`to-spec` / `to-tickets` / `implement` / `wayfinder` などへ発展しています。
 
 ---
 
-## 設計思想：4 つの失敗モード
+## インストール
 
-Matt 氏は、AI エージェントによる開発で起きがちな問題を 4 つに整理し、それぞれに対応するスキルを用意しています。
+### Agent Skills対応エージェント
 
-| 失敗モード | 内容 | 対応スキル |
-|-----------|------|-----------|
-| **Misalignment（認識のズレ）** | 開発者の意図とエージェントの理解が食い違う | `/grill-me`・`/grill-with-docs` で着手前に認識を揃える |
-| **Excessive Verbosity（冗長さ）** | やり取りが長くなり非効率 | 共通ドメイン言語（`CONTEXT.md`）でトークン効率・一貫性を改善 |
-| **Broken Code（壊れたコード）** | 動かない・質の低いコードを生む | 静的型・ブラウザ・自動テストによるフィードバックループ（red-green-refactor） |
-| **Architectural Decay（設計の劣化）** | 場当たり的な変更で設計が崩れる | `/to-prd`・`/improve-codebase-architecture` で日々設計に投資 |
-
----
-
-## インストール方法
-
-```bash
+```powershell
 npx skills@latest add mattpocock/skills
 ```
 
-セットアップ手順：
+導入時に `setup-matt-pocock-skills` を選択し、対象リポジトリで一度実行します。Issue tracker、トリアージ用ラベル、文書の保存先を設定します。
 
-1. 導入したいスキルと対象エージェントを選択（`setup-matt-pocock-skills` を必ず含める）
-2. `/setup-matt-pocock-skills` を実行し、以下を設定：
-   - **イシュートラッカー**（GitHub / Linear / ローカルファイル）
-   - チケットの **トリアージ用ラベル**
-   - **ドキュメントの保存先**
+### Claude Codeプラグイン
 
----
+```text
+/plugin marketplace add mattpocock/skills
+/plugin install mattpocock-skills@mattpocock
+```
 
-## スキル一覧
+シェルから導入する場合：
 
-### 🛠 エンジニアリング
+```powershell
+claude plugin marketplace add mattpocock/skills
+claude plugin install mattpocock-skills@mattpocock
+```
 
-#### ユーザー呼び出し（`/` コマンド）
-
-| スキル | 用途 |
-|-------|------|
-| **ask-matt** | 状況に応じて最適なスキルへ案内する入口 |
-| **grill-with-docs** | 詳細なヒアリングでドメインモデルを構築し、プロジェクト文書を更新 |
-| **triage** | イシューをステートマシンで管理するトリアージ |
-| **improve-codebase-architecture** | アーキテクチャ改善点を洗い出し HTML レポートで提示 |
-| **setup-matt-pocock-skills** | リポジトリ向けにスキル群を初期設定 |
-| **to-issues** | 計画を縦割り（vertical slice）の独立したイシューに分解 |
-| **to-prd** | 議論を正式な PRD（要件定義書）に整理 |
-| **prototype** | 設計検証用の使い捨てプロトタイプを作成 |
-
-#### モデル呼び出し（自動）
-
-| スキル | 用途 |
-|-------|------|
-| **diagnosing-bugs** | 構造化されたデバッグループで原因を切り分け |
-| **tdd** | red-green-refactor のテスト駆動開発 |
-| **domain-modeling** | プロジェクトのドメインモデルを構築・洗練 |
-| **codebase-design** | 保守しやすいモジュール設計の原則を確立 |
-
-### ⚡ 生産性（Productivity）
-
-#### ユーザー呼び出し
-
-| スキル | 用途 |
-|-------|------|
-| **grill-me** | 計画や設計について徹底的にヒアリング（認識合わせ） |
-| **handoff** | エージェント間の引き継ぎ用にコンパクトな handoff 文書を作成 |
-| **teach** | 複数セッションにまたがって新しい概念を教える |
-| **writing-great-skills** | 質の高いスキルを書くためのリファレンス |
-
-#### モデル呼び出し
-
-| スキル | 用途 |
-|-------|------|
-| **grilling** | （自動）深掘りヒアリングのプロセス |
-
-### 🧩 その他（Misc）
-
-| スキル | 用途 |
-|-------|------|
-| **git-guardrails-claude-code** | 危険な git コマンドをブロックするガードレール |
-| **migrate-to-shoehorn** | テストアサーションを TypeScript 向けツール（shoehorn）へ移行 |
-| **scaffold-exercises** | 構造化された演習ディレクトリを作成 |
-| **setup-pre-commit** | lint・テスト付きの pre-commit フックを設定 |
+| 導入方法 | 特徴 |
+|----------|------|
+| `npx skills` | プロジェクトへコピーされ、自分向けに編集できる。Codexなどにも導入可能 |
+| Claude Codeプラグイン | 読み取り専用の管理された一式として更新を追従する |
 
 ---
 
-## 注目スキルの使いどころ
+## 設計思想：4つの失敗モード
 
-- **着手前の認識合わせ** — `/grill-me` や `/grill-with-docs` で、実装に入る前にエージェントへ要件を深掘りさせる。手戻りを大きく減らせます。
-- **計画 → PRD → イシュー化** — `/to-prd` で要件をまとめ、`/to-issues` で縦割りの独立タスクに分解。エージェントが拾いやすい単位になります。
-- **品質を保つ開発ループ** — `tdd` と `diagnosing-bugs` で red-green-refactor を徹底し、壊れたコードを早期に検出。
-- **設計の劣化を防ぐ** — `/improve-codebase-architecture` で定期的にアーキテクチャを点検し、HTML レポートで可視化。
-- **安全な git 運用** — `git-guardrails-claude-code` で `push --force` などの危険操作をブロック。
+| 失敗モード | 問題 | 対応 |
+|------------|------|------|
+| **Misalignment** | 開発者の意図とエージェントの理解がずれる | `grill-me` / `grill-with-docs` で着手前に質問を重ねる |
+| **Excessive Verbosity** | 用語が揃わず説明が長くなる | `CONTEXT.md` とドメインモデルで共通言語を作る |
+| **Broken Code** | 実行時のフィードバックがなく壊れたコードを作る | `tdd` / `diagnosing-bugs` で検証ループを回す |
+| **Architectural Decay** | 高速な変更で設計の劣化も加速する | `to-spec` / `codebase-design` / `improve-codebase-architecture` を使う |
 
 ---
 
-## 他のスキル集との違い
+## Engineering Skills
+
+### ユーザー呼び出し
+
+ユーザーが明示的に起動し、複数の作業を編成するSkillです。
+
+| Skill | 用途 |
+|-------|------|
+| **ask-matt** | 現在の状況に適したSkillや進め方を案内する |
+| **grill-with-docs** | 深掘り質問を行い、用語集、`CONTEXT.md`、ADRも更新する |
+| **triage** | Issueを役割ベースの状態機械でトリアージする |
+| **improve-codebase-architecture** | コードベースの改善候補をHTMLレポートで示し、対象を深掘りする |
+| **setup-matt-pocock-skills** | Issue tracker、ラベル、文書構成をリポジトリへ設定する |
+| **to-spec** | 現在の会話を仕様へ整理し、Issue trackerへ公開する |
+| **to-tickets** | 計画や仕様を、依存関係を持つtracer-bullet型チケットへ分解する |
+| **implement** | 仕様やチケットを実装し、合意した境界でTDDとコードレビューを回す |
+| **wayfinder** | 1セッションでは収まらない大規模作業を調査チケットの地図にする |
+
+### モデル呼び出し
+
+ユーザーからの明示指定に加え、タスクに合えばモデルが自動選択できるSkillです。
+
+| Skill | 用途 |
+|-------|------|
+| **prototype** | 設計上の問いに答えるため、使い捨ての実行可能プロトタイプを作る |
+| **diagnosing-bugs** | 再現→最小化→仮説→計測→修正→回帰テストの順で診断する |
+| **research** | 信頼度の高い一次情報を調査し、引用付きMarkdownとして記録する |
+| **tdd** | red-green-refactorを垂直スライス単位で進める |
+| **domain-modeling** | 用語、境界条件、エッジケースを通してドメインモデルを更新する |
+| **codebase-design** | 小さなインターフェースの背後に多くの振る舞いを持つ深いモジュールを設計する |
+| **code-review** | StandardsとSpecの2軸を別々にレビューする |
+| **resolving-merge-conflicts** | merge / rebaseの競合を、両側の意図と一次情報からhunk単位で解決する |
+
+---
+
+## Productivity Skills
+
+### ユーザー呼び出し
+
+| Skill | 用途 |
+|-------|------|
+| **grill-me** | 計画や設計の意思決定を、分岐が解決するまで質問で詰める |
+| **handoff** | 現在の会話を、別エージェントが継続できるhandoff文書へ圧縮する |
+| **teach** | ディレクトリを状態保存に使い、複数セッションで概念を教える |
+| **writing-great-skills** | 予測可能なSkillを書くための語彙と設計原則を提供する |
+
+### モデル呼び出し
+
+| Skill | 用途 |
+|-------|------|
+| **grilling** | `grill-me` / `grill-with-docs` が共通利用する深掘り質問ループ |
+
+---
+
+## 推奨ワークフロー
+
+```text
+grill-with-docs
+  ↓ 要件・用語・判断を整理
+to-spec
+  ↓ 会話を仕様化
+to-tickets
+  ↓ 依存関係を持つ実装単位へ分解
+implement
+  ├─ tdd
+  ├─ diagnosing-bugs
+  └─ code-review
+```
+
+大規模で不確実性が高い作業では、最初に `wayfinder` を使い、`research` で調査結果を一次情報付きで蓄積します。
+
+---
+
+## 他のSkill集との違い
 
 | | **mattpocock/skills** | **[anthropics/skills](anthropics-skills.md)** | **[superpowers](superpowers.md)** |
-|--|----------------------|---------------------|-----------------------|
-| 主眼 | 開発プロセス（SDLC）の改善 | 汎用タスク（文書生成・デザイン等） | SDLC スキルフレームワーク |
-| 代表スキル | grill-me / to-prd / tdd | docx / pdf / pptx / xlsx | brainstorming / TDD / systematic-debugging |
-| インストール | `npx skills add` | `/plugin install` | `/plugin marketplace add` |
-| 設計思想 | 4 つの失敗モードへの対処 | 自己完結型ツールキット | 体系的な開発ワークフロー |
-
-> いずれも Claude Code で利用できます。プロセス改善目的なら mattpocock/skills や superpowers、ファイル生成・事務作業なら anthropics/skills が向いています。
+|--|----------------------|----------------------------------------------|-----------------------------------|
+| 主眼 | 実務開発プロセスを小さなSkillとして構成 | 文書・表計算・デザイン等の成果物作成 | SDLC全体に規律を強制するフレームワーク |
+| 代表例 | grill-with-docs / to-spec / implement / code-review | docx / pdf / pptx / xlsx | brainstorming / TDD / systematic-debugging |
+| カスタマイズ | コピーして改変しやすい | 公式Skillを用途別に利用 | 定められた開発フローを強く適用 |
+| 対応 | skills.sh対応エージェント、Claude Codeプラグイン | 主にClaude環境 | Claude Code、Codex、Copilot CLI等 |
 
 ---
 
 ## 参考リンク
 
 - [mattpocock/skills](https://github.com/mattpocock/skills) — 公式リポジトリ
-- [Matt Pocock](https://www.mattpocock.com/) — 著者（Total TypeScript 等で知られる）
-- [Claude Code スキル](claude-code-skills.md) — スキルの実行環境
-- [Anthropic 公式スキル](anthropics-skills.md) / [superpowers](superpowers.md) — 他のスキル集
+- [skills.sh: mattpocock/skills](https://skills.sh/mattpocock/skills) — Skill一覧と導入
+- [Matt Pocock](https://www.mattpocock.com/) — 作者
+- [2026年7月版 Skills最新動向](skills-ecosystem-2026.md)
+- [Anthropic公式Skills](anthropics-skills.md) / [superpowers](superpowers.md)
 
 ---
 
-> **注意**: 本ドキュメントは [mattpocock/skills](https://github.com/mattpocock/skills) の公開情報を元にした日本語解説です。収録スキルや使い方は更新されることがあるため、最新情報は公式リポジトリを確認してください。
+> **更新基準日：2026年7月22日**。本ページは公式リポジトリのREADMEとSkill定義を元にした日本語解説です。

--- a/docs/skills-ecosystem-2026.md
+++ b/docs/skills-ecosystem-2026.md
@@ -1,0 +1,226 @@
+# 2026年7月版：Agent Skills・MCP・GUI 自動化の最新動向
+
+> Agent Skills は `SKILL.md` だけで完結する仕組みから、MCP、Web データ取得、デプロイ、Computer Use と組み合わさる実行基盤へ広がっています。本ページでは、2026年7月22日時点で注目度の高い6テーマを公式情報に基づいて整理します。
+
+## 動画チャプター対応表
+
+| 時刻 | テーマ | このページで扱う内容 |
+|------|--------|----------------------|
+| 07:43 | Matt Pocock's Skills | 実務開発プロセスを分割・合成可能なSkillにする |
+| 15:08 | Context7 | 最新のライブラリ文書をSkillsまたはMCPで取得する |
+| 15:55 | Firecrawl | 検索・スクレイピング・ブラウザ操作をエージェントへ追加する |
+| 18:41 | Vercel | Agent Skillsの配布基盤とVercel公式Skill集 |
+| 21:08 | Record & Replay | 人間の操作を見せて再利用可能なSkillへ変換する |
+| 24:51 | Computer Use / Browser Use | デスクトップ／ブラウザGUIを視覚的に操作する |
+
+> `Versel` ではなく、正式な表記は **Vercel** です。
+
+---
+
+## 全体像
+
+| 分類 | 代表例 | エージェントに追加するもの | 向いている用途 |
+|------|--------|----------------------------|----------------|
+| 開発プロセス | mattpocock/skills | 要件整理、設計、TDD、レビューの手順 | AI駆動開発の品質安定化 |
+| 最新ドキュメント | Context7 | バージョン別API・コード例 | ライブラリ仕様の確認 |
+| Webデータ | Firecrawl | 検索、抽出、クロール、操作 | 調査、RAG、サイト分析 |
+| Skill配布・実践 | Vercel / skills.sh | Skillの検索・導入、React等の公式知見 | Skill導入とWeb開発 |
+| 操作の記録 | Record & Replay | 実演から生成した再利用可能なSkill | 定型GUI業務 |
+| GUI実行 | Computer Use / Browser Use | 画面認識、クリック、入力、検証 | APIのないアプリやWeb画面 |
+
+---
+
+## 1. Matt Pocock's Skills
+
+[mattpocock/skills](https://github.com/mattpocock/skills) は、「vibe coding」ではなく実務エンジニアリングを安定して進めるためのSkill集です。巨大な一枚岩の開発手順ではなく、小さく変更しやすいSkillを組み合わせます。
+
+2026年7月時点では、従来の `to-prd` / `to-issues` から、現在の構成へ発展しています。
+
+| 段階 | 主なSkill | 役割 |
+|------|-----------|------|
+| 認識合わせ | `grill-me` / `grill-with-docs` | 曖昧な要件や設計判断を質問で詰める |
+| 仕様化 | `to-spec` | 会話を仕様としてIssue trackerへ公開する |
+| タスク分解 | `to-tickets` | 依存関係を持つtracer-bullet型チケットへ分解する |
+| 実装 | `implement` / `tdd` | 合意した境界でTDDを回しながら実装する |
+| 長期調査 | `wayfinder` / `research` | 1セッションを超える調査を分割し、一次情報を記録する |
+| 品質確認 | `code-review` / `diagnosing-bugs` | 仕様と標準の2軸レビュー、体系的デバッグを行う |
+
+### インストール
+
+```powershell
+npx skills@latest add mattpocock/skills
+```
+
+Claude Codeでは管理されたプラグインとして導入する方法もあります。
+
+```text
+/plugin marketplace add mattpocock/skills
+/plugin install mattpocock-skills@mattpocock
+```
+
+詳しくは [mattpocock/skills 日本語解説](mattpocock-skills.md) を参照してください。
+
+---
+
+## 2. Context7
+
+[Context7](https://github.com/upstash/context7) は、利用中のライブラリに対応した最新・バージョン別のドキュメントとコード例を、エージェントのコンテキストへ取り込む仕組みです。
+
+### 2つの利用形態
+
+| 形態 | 仕組み | 特徴 |
+|------|--------|------|
+| CLI + Skills | Skillが `ctx7` CLIを呼ぶ | MCPなしで利用できる |
+| MCP | `resolve-library-id` / `query-docs` をツールとして公開 | エージェントが必要時にネイティブ呼び出しできる |
+
+### セットアップ
+
+```powershell
+npx ctx7 setup
+```
+
+特定バージョンやライブラリIDを明示すると、曖昧なマッチングを減らせます。
+
+```text
+Next.js 14 のMiddlewareを実装して。use context7
+Supabase認証を /supabase/supabase の文書に基づいて実装して。
+```
+
+> APIキーなしでも始められる構成がありますが、公式READMEでは高いrate limitを得るため無料APIキーを推奨しています。また、公開リポジトリはMCPサーバーのソースであり、APIバックエンド・解析・クロール基盤は非公開です。
+
+---
+
+## 3. Firecrawl
+
+[Firecrawl](https://github.com/firecrawl/firecrawl) は、Webを検索・取得し、LLMが扱いやすいMarkdownや構造化JSONへ変換するWeb context基盤です。2026年には、APIだけでなくSkills、Codexプラグイン、MCPとしても利用できます。
+
+### 主な機能
+
+| 機能 | 用途 |
+|------|------|
+| Search | Web検索と検索結果本文の取得 |
+| Scrape | URLをMarkdown、HTML、JSON、スクリーンショットへ変換 |
+| Crawl / Map | サイト全体の巡回、URL一覧化 |
+| Interact | クリック、入力、待機などを行ってから抽出 |
+| Agent | 必要な情報を自然言語で指定して自律収集 |
+| Parse | Web上のPDF・DOCXなどから情報を抽出 |
+
+### Skillとして導入
+
+```powershell
+npx -y firecrawl-cli@latest init --all --browser
+```
+
+用途別には、次の公式配布物があります。
+
+- [firecrawl-codex-plugin](https://github.com/firecrawl/firecrawl-codex-plugin) — Codex向けに検索・抽出・クロール等のSkillをまとめたプラグイン
+- [firecrawl-claude-plugin](https://github.com/firecrawl/firecrawl-claude-plugin) — Claude Code向けSkill
+- [firecrawl-mcp-server](https://github.com/firecrawl/firecrawl-mcp-server) — MCP互換クライアント向け
+- [firecrawl-workflows](https://github.com/firecrawl/firecrawl-workflows) — 調査レポート、SEO監査、QA、ナレッジベース等の成果物指向Skill
+
+> Context7が「ライブラリ文書の取得」に特化するのに対し、Firecrawlは「一般のWebを検索・抽出・操作する」ための基盤です。
+
+---
+
+## 4. Vercel：Skills配布基盤と公式Skill集
+
+Vercel周辺には、役割の異なる2つのプロジェクトがあります。
+
+### vercel-labs/skills
+
+[vercel-labs/skills](https://github.com/vercel-labs/skills) は、Agent Skillsを検索・インストールする `npx skills` CLIの公式リポジトリです。[skills.sh](https://skills.sh/) が公開Skillの検索入口になります。
+
+```powershell
+npx skills find react
+npx skills add vercel-labs/agent-skills
+```
+
+### vercel-labs/agent-skills
+
+[vercel-labs/agent-skills](https://github.com/vercel-labs/agent-skills) は、Vercel公式のWeb開発向けSkill集です。
+
+| Skill | 主な用途 |
+|-------|----------|
+| `vercel-optimize` | Vercelのコスト、性能、キャッシュ、Functions利用状況を監査 |
+| `react-best-practices` | React / Next.jsの性能ルールを適用 |
+| `web-design-guidelines` | アクセシビリティ、性能、UXを監査 |
+| `writing-guidelines` | Vercelの文書作成ルールでレビュー |
+| `react-native-guidelines` | React Native / Expoの性能・設計を確認 |
+| `react-view-transitions` | React View Transition APIを実装 |
+| `composition-patterns` | boolean propsの増殖を避ける構成へ改善 |
+| `vercel-deploy-claimable` | 会話から譲渡可能なVercelデプロイを作成 |
+
+> Next.js固有のAgent Skillsは、バージョンとのずれを防ぐため [vercel/next.js の `skills` ディレクトリ](https://github.com/vercel/next.js/tree/canary/skills) へ移動しています。
+
+---
+
+## 5. Codex Record & Replay
+
+[Record & Replay](https://learn.chatgpt.com/docs/extend/record-and-replay) は、ユーザーがMac上で行う作業をCodexに見せ、その実演から再利用可能なSkillを作成する機能です。単純な座標マクロではなく、手順の意図・入力・成功条件を整理したSkillを生成し、再実行時には利用可能なツールを選択します。
+
+### 向いている作業
+
+- 経費申請、駐車場予約などの定型業務
+- 設定済みIssueの作成
+- 動画の公開
+- 定期レポートのダウンロード
+- 手順は安定しているが、文章で説明するより見せた方が早い作業
+
+### 重要な条件
+
+- 2026年7月時点では **macOSで利用可能**
+- 初期提供地域からEEA、英国、スイスは除外
+- **Computer Useが有効**であることが前提
+- `requirements.toml` で `[features].computer_use = false` の場合は利用不可
+- 複数Skill、MCP、コネクタ、配布メタデータまでまとめる場合はPlugin化が適する
+
+---
+
+## 6. Computer Use / Browser Use
+
+[Computer Use](https://learn.chatgpt.com/docs/computer-use) は、CodexまたはChatGPT WorkがGUIを見て、クリック、入力、メニュー操作、画面検証を行う機能です。CLIやMCPでは届かないデスクトップアプリや、APIのない画面操作に使います。
+
+### Browser Useとの関係
+
+| 機能 | 操作対象 | 特徴 |
+|------|----------|------|
+| Built-in browser | ChatGPT内の独立ブラウザプロファイル | 通常のブラウザとはCookieやログイン状態を共有しない |
+| Computer Use in browser | 組み込みブラウザ上のWeb UI | ページを開く、クリック、入力、スクリーンショット、結果確認 |
+| Chrome連携 | ユーザーが許可したChrome環境 | ログイン済みサイトを扱えるが、許可範囲を絞る必要がある |
+| Desktop Computer Use | macOS / Windowsアプリ | APIのないGUI操作、設定変更、GUI固有バグの再現 |
+
+### OSごとの差
+
+- **macOS** — Screen RecordingとAccessibility権限が必要。対応構成ではバックグラウンド利用やLocked useがある。
+- **Windows** — アクティブなデスクトップを前景で操作するため、実行中はポインターやキーボード操作を占有する。
+
+> 対象サービスに専用Plugin、コネクタ、MCPがある場合は、データ取得や反復処理では構造化された連携を優先します。Computer Useは、画面を見なければ判断・操作できない場面に絞ると安定します。
+
+---
+
+## 使い分け
+
+| やりたいこと | 第一候補 |
+|--------------|----------|
+| 最新のReact / AWS SDK等の使い方を知りたい | Context7 |
+| 複数サイトを調査し、MarkdownやJSONにしたい | Firecrawl |
+| React / Next.jsコードを公式ルールで監査したい | Vercel Agent Skills |
+| 要件整理からTDD・レビューまでの開発手順を改善したい | Matt Pocock's Skills |
+| 毎回同じGUI操作をSkill化したい | Record & Replay |
+| APIのないデスクトップ／Web画面を直接操作したい | Computer Use / Browser Use |
+
+---
+
+## 参考リンク
+
+- [mattpocock/skills](https://github.com/mattpocock/skills)
+- [upstash/context7](https://github.com/upstash/context7)
+- [firecrawl/firecrawl](https://github.com/firecrawl/firecrawl)
+- [vercel-labs/skills](https://github.com/vercel-labs/skills)
+- [vercel-labs/agent-skills](https://github.com/vercel-labs/agent-skills)
+- [OpenAI Record & Replay](https://learn.chatgpt.com/docs/extend/record-and-replay)
+- [OpenAI Computer Use](https://learn.chatgpt.com/docs/computer-use)
+
+---
+
+> **更新基準日：2026年7月22日**。Skillの名称、導入方法、提供地域は変わる可能性があるため、導入時は各公式リンクを確認してください。


### PR DESCRIPTION
## 概要

2026年7月22日時点のAgent Skills周辺動向を、公式リポジトリとOpenAI公式ドキュメントに基づいて日本語で整理しました。

## 変更内容

- `docs/skills-ecosystem-2026.md` を追加
  - Matt Pocock's Skills
  - Context7
  - Firecrawl
  - Vercel / skills.sh
  - Codex Record & Replay
  - Computer Use / Browser Use
- `docs/mattpocock-skills.md` を現在の構成へ更新
  - `to-spec` / `to-tickets` / `implement` / `wayfinder`
  - `research` / `code-review` / `resolving-merge-conflicts`
  - Claude Codeプラグインとskills.shの導入方法
- READMEに新規ガイドへの導線を追加
- 入力にあった `Versel` は正式名の `Vercel` へ修正

## 情報源

各プロジェクトの公式GitHubリポジトリ、およびOpenAI公式のRecord & Replay / Computer Useドキュメントを使用しています。

## 確認

- mainとの差分は3ファイルのみ
- Markdownコードフェンスの対応を確認
- 内部リンク先のパスを確認
- 旧Skill名は移行説明としてのみ残存
