### PR TITLE
docs: Skills の発見・配布・更新の最新動向を追加（gh skill / Agent Finder・ARD / Copilot Plugins）

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 ## 2026-08
 
-- **2026-08-01** [Skills 最新動向](docs/trends.md) に「Skill の発見・配布・更新」を追加し、[GitHub Copilot Plugins](docs/copilot/plugins.md) を新設（#84）
-  - 参照した公式情報: [Manage agent skills with GitHub CLI](https://github.blog/changelog/2026-04-16-manage-agent-skills-with-github-cli/) / [gh skill マニュアル](https://cli.github.com/manual/gh_skill) / [Agent finder for GitHub Copilot now available](https://github.blog/changelog/2026-06-17-agent-finder-for-github-copilot-now-available/) / [ARD Specification](https://agenticresourcediscovery.org/spec/) / [About GitHub Copilot plugins](https://docs.github.com/en/copilot/concepts/agents/about-plugins) / [Finding and installing plugins for GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-finding-installing)
+- **2026-08-01** [Skills 最新動向](docs/trends.md) に「Skill の発見・配布・更新」を追加し、[GitHub Copilot Plugins](docs/copilot/plugins.md) を新設（#84）。公開後に一次情報（`cli.github.com`・`docs.github.com` 原文）で内容を検証し、`gh skill install` の `--agent` 指定例の誤り（`copilot` → 正しくは `github-copilot`）等を修正
+  - 参照した公式情報: [Manage agent skills with GitHub CLI](https://github.blog/changelog/2026-04-16-manage-agent-skills-with-github-cli/) / [gh skill マニュアル](https://cli.github.com/manual/gh_skill)（install/update/publish/preview/search 各サブコマンドページ含む） / [Agent finder for GitHub Copilot now available](https://github.blog/changelog/2026-06-17-agent-finder-for-github-copilot-now-available/) / [ARD Specification](https://agenticresourcediscovery.org/spec/) / [AI Catalog Standard](https://agenticresourcediscovery.org/ai_catalog_spec/) / [About GitHub Copilot plugins](https://docs.github.com/en/copilot/concepts/agents/about-plugins) / [Finding and installing plugins for GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-finding-installing) / [GitHub Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference)
 
 ## 2026-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 本ガイドの主な更新を時系列で記録します。upstream の新規スキル検出への対応と、ガイド本体の構成変更・解説追加をここにまとめます。
 
+## 2026-08
+
+- **2026-08-01** [Skills 最新動向](docs/trends.md) に「Skill の発見・配布・更新」を追加し、[GitHub Copilot Plugins](docs/copilot/plugins.md) を新設（#84）
+  - 参照した公式情報: [Manage agent skills with GitHub CLI](https://github.blog/changelog/2026-04-16-manage-agent-skills-with-github-cli/) / [gh skill マニュアル](https://cli.github.com/manual/gh_skill) / [Agent finder for GitHub Copilot now available](https://github.blog/changelog/2026-06-17-agent-finder-for-github-copilot-now-available/) / [ARD Specification](https://agenticresourcediscovery.org/spec/) / [About GitHub Copilot plugins](https://docs.github.com/en/copilot/concepts/agents/about-plugins) / [Finding and installing plugins for GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-finding-installing)
+
 ## 2026-07
 
 - **2026-07-29** 「Skills 最新動向」を常設ページ化し、更新履歴（本ページ）を新設（#77）

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@
 
 ```
 docs/
-  copilot/       # GitHub Copilot 専用（instructions / agents / prompts）
+  copilot/       # GitHub Copilot 専用（instructions / agents / prompts / plugins）
   claude-code/   # Claude Code 専用（基本ガイド・Anthropic 公式スキル）
   codex/         # Codex（OpenAI）専用
   dev-methods/   # ツール横断の開発手法（mattpocock/skills・superpowers・AI-DLC）

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 | 💬 まず生成AIを触ってみたい（コードは書かない） | [非エンジニア向けクイックスタート](#-非エンジニア向けクイックスタート) |
 | 📋 業務シーン別に「使える例」を見たい | [シナリオ別ユースケース集](docs/business/use-cases.md) |
 | 🌐 Skills・MCP・GUI自動化の最新動向をまとめて知りたい | [Skills 最新動向](docs/trends.md) |
-| 🔎 Skill の探し方・バージョン固定・組織配布を知りたい | [Skills 最新動向](docs/trends.md) の「Skill の発見・配布・更新」 |
+| 🔎 Skill の探し方・バージョン固定・組織配布を知りたい | [Skills 最新動向](docs/trends.md#7-skill-の発見配布更新)（「Skill の発見・配布・更新」） |
 | 🆕 このガイドの最近の更新を知りたい | [更新履歴（CHANGELOG）](CHANGELOG.md) |
 | 📝 議事録・請求書・資料など事務作業を効率化したい | [事務・バックオフィス活用ガイド](docs/business/office-work.md) |
 | 💹 決算・経理・金融業務を効率化したい | [金融サービス向けスキル](docs/business/financial-services.md) |

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@
 | 💬 まず生成AIを触ってみたい（コードは書かない） | [非エンジニア向けクイックスタート](#-非エンジニア向けクイックスタート) |
 | 📋 業務シーン別に「使える例」を見たい | [シナリオ別ユースケース集](docs/business/use-cases.md) |
 | 🌐 Skills・MCP・GUI自動化の最新動向をまとめて知りたい | [Skills 最新動向](docs/trends.md) |
+| 🔎 Skill の探し方・バージョン固定・組織配布を知りたい | [Skills 最新動向](docs/trends.md) の「Skill の発見・配布・更新」 |
 | 🆕 このガイドの最近の更新を知りたい | [更新履歴（CHANGELOG）](CHANGELOG.md) |
 | 📝 議事録・請求書・資料など事務作業を効率化したい | [事務・バックオフィス活用ガイド](docs/business/office-work.md) |
 | 💹 決算・経理・金融業務を効率化したい | [金融サービス向けスキル](docs/business/financial-services.md) |
@@ -41,6 +42,7 @@
 | ⌨️ コーディング規約を Copilot に守らせたい | [Instructions 一覧](docs/copilot/instructions.md) |
 | 🧑‍💻 Copilot を専門家として使いたい | [Agents 一覧](docs/copilot/agents.md) |
 | ⚡ `/` コマンドで定型タスクを実行したい | [Prompts / Skills 一覧](docs/copilot/prompts.md) |
+| 📦 チームへ拡張一式をまとめて配布したい | [Plugins](docs/copilot/plugins.md) |
 
 ### Claude Code
 
@@ -85,6 +87,7 @@
 | **[Instructions 一覧](docs/copilot/instructions.md)** | ファイルパターンに応じてコーディング規約を自動適用するルールファイルの詳細解説 | 197 件 |
 | **[Agents 一覧](docs/copilot/agents.md)** | Copilot を特定ドメインの専門家ペルソナとして振る舞わせるエージェント定義の詳細解説 | 240 件 |
 | **[Prompts / Skills 一覧](docs/copilot/prompts.md)** | `/` コマンドから呼び出せる再利用可能なタスクテンプレートおよび Skills の詳細解説 | 137 件 |
+| **[Plugins](docs/copilot/plugins.md)** | Agents / Skills / Hooks / MCP / LSP を 1 つの単位で配布する Plugin、Marketplace、`enabledPlugins` の詳細解説 | — |
 
 ### Claude Code
 
@@ -114,7 +117,7 @@
 | **[シナリオ別ユースケース集](docs/business/use-cases.md)** | 役割・業務シーンから探す生成AIの実例カタログ（プロンプト例つき） | — |
 | **[事務・バックオフィス活用ガイド](docs/business/office-work.md)** | 議事録・請求書・レポート・スプレッドシート作成など、日々の事務作業を生成AIで効率化する実践ガイド | — |
 | **[金融サービス向けスキル](docs/business/financial-services.md)** | [anthropics/financial-services](https://github.com/anthropics/financial-services) 収録の金融・経理業務向けエージェント／スキル（決算照合・月次決算・KYC 等）の詳細解説 | 10 エージェント + 7 業務プラグイン |
-| **[Skills 最新動向](docs/trends.md)** | Matt Pocock、Context7、Firecrawl、Vercel、Record & Replay、Computer Use / Browser Use の比較と使い分け（常設・随時更新） | 6 テーマ |
+| **[Skills 最新動向](docs/trends.md)** | Matt Pocock、Context7、Firecrawl、Vercel、Record & Replay、Computer Use / Browser Use、Skill の発見・配布・更新（`gh skill` / Agent Finder・ARD / Copilot Plugins）の比較と使い分け（常設・随時更新） | 7 テーマ |
 | **[更新履歴（CHANGELOG）](CHANGELOG.md)** | 本ガイドの構成変更・解説追加・upstream 対応の時系列記録 | — |
 
 ---
@@ -140,6 +143,7 @@
 | **Instructions** | ファイルパターン別にコーディング規約を自動適用（`.instructions.md`） | `CLAUDE.md` がほぼ同じ役割 | `AGENTS.md` がほぼ同じ役割 |
 | **Prompts** | `/` コマンドのタスクテンプレート（`.prompt.md`） | カスタムコマンド（`.claude/commands/`） | カスタムプロンプト（`~/.codex/prompts/`） |
 | **Hooks** | コーディングエージェントセッションのイベント駆動スクリプト（`hooks.json`） | `PreToolUse` / `PostToolUse` 等のイベント駆動自動化 | — |
+| **Plugins** | Agents / Skills / Hooks / MCP / LSP をまとめた配布単位（`plugin.json`）。Marketplace から導入（[解説](docs/copilot/plugins.md)） | Skills / Commands / Subagents / Hooks / MCP をまとめた配布単位。`/plugin marketplace add` で導入 | Skill・MCP・コネクタ等をまとめた配布単位（例: firecrawl-codex-plugin） |
 
 > 各ドキュメントの冒頭には「**対象ツール**」ヘッダーを付けています。どのツールの話か迷ったら、ページ先頭とこの表を確認してください。
 

--- a/docs/copilot/README.md
+++ b/docs/copilot/README.md
@@ -1,6 +1,6 @@
 # GitHub Copilot ガイド
 
-> **対象ツール**: GitHub Copilot ｜ **対象読者**: エンジニア ｜ **最終更新**: 2026-07-29
+> **対象ツール**: GitHub Copilot ｜ **対象読者**: エンジニア ｜ **最終更新**: 2026-08-01
 
 GitHub Copilot は GitHub が提供するコーディングアシスタントで、IDE 内のインライン補完・チャットが中心です。このページでは、Copilot のカスタマイズの種類と設定方法、クイックスタートを解説します。
 
@@ -11,6 +11,7 @@ GitHub Copilot は GitHub が提供するコーディングアシスタントで
 | **[Instructions 一覧](instructions.md)** | ファイルパターンに応じてコーディング規約を自動適用するルールファイルの詳細解説 |
 | **[Agents 一覧](agents.md)** | Copilot を特定ドメインの専門家ペルソナとして振る舞わせるエージェント定義の詳細解説 |
 | **[Prompts / Skills 一覧](prompts.md)** | `/` コマンドから呼び出せる再利用可能なタスクテンプレートおよび Skills の詳細解説 |
+| **[Plugins](plugins.md)** | Agents / Skills / Hooks / MCP / LSP を 1 つの単位で配布する Plugin と Marketplace の詳細解説 |
 
 ---
 
@@ -23,6 +24,7 @@ GitHub Copilot は GitHub が提供するコーディングアシスタントで
 | [Agents](#agents---専門家ペルソナ) | `.agent.md` | 特定ドメインの専門家として振る舞うペルソナ | チャットで手動選択 |
 | [Skills](#skills---リソース同梱の複合ツール) | `SKILL.md` + 関連ファイル | upstream の `skills/` で公開される、関連リソース同梱の自己完結型ツール | チャットで手動実行 |
 | [Collections](#collections---カスタマイズのセット) | `.collection.yml` | 上記を組み合わせたキュレーション済みセット | プロジェクト単位で適用 |
+| [Plugins](#plugins---拡張をまとめた配布単位) | `plugin.json` + 各要素 | Agents / Skills / Hooks / MCP / LSP をまとめて配布・更新する単位 | インストール後は常時有効 |
 | [Hooks](#hooks---セッションイベント駆動の自動アクション) | `hooks.json` + スクリプト | Copilot コーディングエージェントのセッションイベントで自動実行 | エージェントセッション中に自動 |
 | [Agentic Workflows](#agentic-workflows---ai-駆動のリポジトリ自動化) | `.md`（フロントマター + 自然言語） | GitHub Actions 上で動く AI 自動化ワークフロー | スケジュール・イベントで自動実行 |
 | [Cookbook](#cookbook-recipes---実践的なコード例) | コードスニペット集 | Copilot SDK を使ったコピー＆ペーストですぐ使えるコード例 | 実装の参考として随時 |
@@ -280,6 +282,33 @@ items:
 
 ---
 
+## Plugins - 拡張をまとめた配布単位
+
+### 概要
+
+Plugins は、Custom Agents・Skills・Hooks・MCP サーバー設定・LSP サーバー設定を `plugin.json` で 1 つにまとめ、Marketplace 経由で配布・更新する仕組みです。Collections が「カスタマイズの推奨セット」を示すのに対し、Plugins は **インストールと更新の単位そのもの** です。
+
+### こんなときに使える
+
+- **チーム標準の拡張一式を配りたい** — Skill だけでなく、Hooks や MCP 接続設定まで含めて 1 コマンドで揃える
+- **リポジトリごとに必要な拡張を固定したい** — `.github/copilot/settings.json` の `enabledPlugins` に書けば、クローンした開発者全員に同じ構成が適用される
+- **組織で使える拡張を制限したい** — Enterprise の managed settings で、許可する Plugin を統制する
+
+### 導入方法
+
+```powershell
+copilot plugin marketplace list
+copilot plugin marketplace browse awesome-copilot
+copilot plugin install database-data-management@awesome-copilot
+copilot plugin update database-data-management
+```
+
+Copilot CLI には `copilot-plugins`（GitHub 公式コレクション）と `awesome-copilot` の 2 つの Marketplace が既定で登録されています。VS Code では **Agent plugins（Preview）** として利用できます。
+
+**→ 構成・Marketplace の作り方・Claude Code Plugin との比較は [plugins.md](plugins.md) を参照**
+
+---
+
 ## Hooks - セッションイベント駆動の自動アクション
 
 ### 概要
@@ -426,6 +455,8 @@ Instructions、Prompts、Agents は GitHub Copilot のすべてのプラン（Fr
 - [Agentic Workflows ドキュメント](https://github.com/github/awesome-copilot/blob/main/docs/README.workflows.md) — AI 駆動ワークフローの一覧
 - [Hooks ドキュメント](https://github.com/github/awesome-copilot/blob/main/docs/README.hooks.md) — セッションイベント駆動フックの一覧
 - [Cookbook](https://github.com/github/awesome-copilot/blob/main/cookbook/README.md) — Copilot SDK を活用した実践的コードレシピ集
+- [About GitHub Copilot plugins](https://docs.github.com/en/copilot/concepts/agents/about-plugins) — Plugin の概念と構成（公式）
+- [Manage agent skills with GitHub CLI](https://github.blog/changelog/2026-04-16-manage-agent-skills-with-github-cli/) — `gh skill` による Skill 管理（公式）
 
 ## 関連ドキュメント
 

--- a/docs/copilot/plugins.md
+++ b/docs/copilot/plugins.md
@@ -1,0 +1,173 @@
+# GitHub Copilot Plugins
+
+> **対象ツール**: GitHub Copilot（CLI / VS Code） ｜ **対象読者**: エンジニア ｜ **最終更新**: 2026-08-01
+
+Plugin は、Custom Agents・Skills・Hooks・MCP サーバー設定・LSP サーバー設定を **1 つの配布単位** にまとめる仕組みです。Skill を 1 個ずつ配る代わりに、チームやプロジェクトに必要な拡張一式をまとめて配布・更新できます。
+
+> **提供状況**: Copilot CLI の Plugin は一般提供、VS Code の Agent plugins は Preview です。名称・コマンドは変わる可能性があるため、導入時は末尾の公式リンクを確認してください。
+
+---
+
+## Skill 単体と Plugin の使い分け
+
+| 観点 | Skill 単体 | Plugin |
+|------|-----------|--------|
+| 配布単位 | `SKILL.md` を含む 1 ディレクトリ | `plugin.json` でまとめた複数の拡張 |
+| 含められる要素 | 手順とその付随リソース | Agents / Skills / Hooks / MCP / LSP |
+| 導入方法 | `gh skill install`、`npx skills add`、手動配置 | `copilot plugin install`、`enabledPlugins` |
+| 向いている場面 | 1 つの作業手順を共有したい | チーム標準の拡張一式を配りたい |
+| 更新の追跡 | Skill 単位（tree SHA・pin） | Plugin 単位（Marketplace のバージョン） |
+
+> 単独の手順だけを配るなら Skill、外部連携（MCP）やイベント自動化（Hooks）まで含めて標準化するなら Plugin が適します。
+
+---
+
+## Plugin の構成
+
+Plugin の必須要素は、ディレクトリ直下の `plugin.json` マニフェストだけです。以下の要素は、必要なものだけを含められます。
+
+| 要素 | 配置場所 | 役割 |
+|------|---------|------|
+| マニフェスト | `plugin.json`（ルート・必須） | Plugin 名、説明、バージョン等のメタデータ |
+| Custom Agents | `agents/*.agent.md` | 専門家ペルソナの定義 |
+| Skills | `skills/<スキル名>/SKILL.md` | 関連リソース同梱の作業手順 |
+| Hooks | ルートまたは `hooks/` の `hooks.json` | エージェントの動作に介入するイベントハンドラー |
+| MCP サーバー設定 | ルートの `.mcp.json` または `.github/mcp.json` | 外部サービス連携（Model Context Protocol） |
+| LSP サーバー設定 | ルートまたは `.github/` の `lsp.json` | 言語サーバー連携（Language Server Protocol） |
+
+```text
+my-plugin/
+  plugin.json            # 必須
+  agents/
+    db-reviewer.agent.md
+  skills/
+    migration-check/
+      SKILL.md
+  hooks.json
+  .mcp.json
+  lsp.json
+```
+
+---
+
+## Marketplace
+
+Marketplace は、Plugin の一覧を持つ **Git リポジトリ** です。リポジトリに `marketplace.json` を置くと、Copilot CLI がそのリポジトリを Marketplace として認識します。GitHub.com のほか、他の Git ホスティングサービスやローカル／共有ファイルシステムにも置けます。
+
+Copilot CLI には、次の 2 つが既定で登録されています。
+
+| Marketplace | 内容 |
+|-------------|------|
+| `copilot-plugins` | [github/copilot-plugins](https://github.com/github/copilot-plugins) — GitHub 公式の Plugin コレクション |
+| `awesome-copilot` | [github/awesome-copilot](https://github.com/github/awesome-copilot) — カスタマイズ公式リポジトリの Plugin 群 |
+
+---
+
+## 導入手順
+
+### 1. Marketplace を確認する
+
+```powershell
+copilot plugin marketplace list
+copilot plugin marketplace browse awesome-copilot
+```
+
+### 2. Plugin をインストールする
+
+```powershell
+copilot plugin install database-data-management@awesome-copilot
+copilot plugin list
+```
+
+Copilot CLI のセッション中は、スラッシュコマンドでも実行できます。
+
+```text
+/plugin install database-data-management@awesome-copilot
+```
+
+### 3. 更新・削除する
+
+```powershell
+copilot plugin update database-data-management
+copilot plugin uninstall database-data-management
+```
+
+### 4. 独自の Marketplace を登録する
+
+```powershell
+copilot plugin marketplace add OWNER/REPO
+copilot plugin marketplace remove MARKETPLACE-NAME
+```
+
+> **注意**: 追加時は Marketplace リポジトリの `OWNER/REPO` を、削除時は登録済み一覧に表示される **Marketplace 名** を指定します。Plugin がインストール済みの Marketplace は、`--force` を付けない限り削除されません（`--force` を付けると、その Marketplace 由来の Plugin も削除されます）。
+
+### インストール先
+
+Copilot CLI は Plugin を `~/.copilot/installed-plugins/<marketplace>/<plugin>/` に保存します。Marketplace を経由せず Git URL から直接インストールした Plugin は `_direct` に入ります。インストールは **開発者ごと・マシンごと** です。
+
+---
+
+## enabledPlugins による標準化
+
+コマンドで 1 つずつ入れる（命令的）方法のほかに、設定ファイルへ書いて宣言的に有効化する方法があります。
+
+| 設定ファイル | 適用範囲 | 用途 |
+|-------------|---------|------|
+| `~/.copilot/settings.json` | ユーザー全体 | 個人が常用する Plugin |
+| `.github/copilot/settings.json` | リポジトリ | そのリポジトリの開発者全員に同じ Plugin を適用 |
+
+```json
+{
+  "enabledPlugins": [
+    "database-data-management@awesome-copilot"
+  ]
+}
+```
+
+リポジトリ側の設定ファイルをコミットしておけば、クローンした開発者が同じ Plugin 構成で作業を始められます。Enterprise では **managed settings** により、利用してよい Plugin を組織のポリシーとして強制できます（VS Code・Copilot CLI・Copilot アプリが対象）。
+
+---
+
+## VS Code での利用
+
+VS Code では **Agent plugins（Preview）** として提供され、「Agent Plugins - Installed」ビューから有効化・無効化・アンインストールができます。有効／無効の状態は Plugin の設定とは別に保存されるため、共有しているワークスペース設定には影響しません。
+
+---
+
+## Claude Code の Plugin Marketplace との比較
+
+| 観点 | GitHub Copilot Plugins | Claude Code Plugins |
+|------|------------------------|---------------------|
+| Marketplace の実体 | Git リポジトリ（`marketplace.json`） | Git リポジトリ（`.claude-plugin/marketplace.json`） |
+| 登録コマンド | `copilot plugin marketplace add OWNER/REPO` | `/plugin marketplace add OWNER/REPO` |
+| インストール | `copilot plugin install NAME@MARKETPLACE` | `/plugin install NAME@MARKETPLACE` |
+| 含められる要素 | Agents / Skills / Hooks / MCP / LSP | Skills / Commands / Subagents / Hooks / MCP |
+| 既定の Marketplace | `copilot-plugins` / `awesome-copilot` | なし（利用者が追加） |
+| 組織での強制 | Enterprise managed settings | 設定ファイルの共有が中心 |
+
+> どちらも「Git リポジトリを配布元にする」「`NAME@MARKETPLACE` 形式で指定する」点は共通です。大きな違いは、含められる要素（Copilot は LSP を含む）と、組織ポリシーによる制御の強さです。
+
+---
+
+## 安全に使うための確認事項
+
+- Plugin は **GitHub による検証済みではありません**。導入前に配布元リポジトリと中身（`SKILL.md`、`hooks.json`、スクリプト）を確認してください。
+- Hooks はエージェントの動作に介入し、MCP は外部サービスへ接続します。**何にアクセスするか**を導入前に把握してください。
+- 組織で配布する場合は、Marketplace リポジトリを自組織で管理し、`enabledPlugins` と managed settings で許可範囲を明示してください。
+
+---
+
+## 参考リンク
+
+- [About GitHub Copilot plugins](https://docs.github.com/en/copilot/concepts/agents/about-plugins) — Plugin の概念と構成（公式）
+- [Finding and installing plugins for GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-finding-installing) — 検索・導入手順（公式）
+- [Creating a plugin marketplace for GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-marketplace) — Marketplace の作り方（公式）
+- [GitHub Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference) — `copilot plugin` コマンドリファレンス（公式）
+- [github/copilot-plugins](https://github.com/github/copilot-plugins) — 公式 Plugin コレクション
+- [Agent plugins in VS Code (Preview)](https://code.visualstudio.com/docs/agent-customization/agent-plugins) — VS Code 側の解説（公式）
+
+## 関連ドキュメント
+
+- [GitHub Copilot ガイド](README.md) — Copilot のカスタマイズ全体像
+- [Skills 最新動向](../trends.md) — `gh skill` / Agent Finder / ARD との位置づけと比較表
+- [superpowers](../dev-methods/superpowers.md) — Copilot CLI へ Plugin として導入できる開発手法スキル集

--- a/docs/copilot/plugins.md
+++ b/docs/copilot/plugins.md
@@ -13,7 +13,7 @@ Plugin は、Custom Agents・Skills・Hooks・MCP サーバー設定・LSP サ�
 | 観点 | Skill 単体 | Plugin |
 |------|-----------|--------|
 | 配布単位 | `SKILL.md` を含む 1 ディレクトリ | `plugin.json` でまとめた複数の拡張 |
-| 含められる要素 | 手順とその付随リソース | Agents / Skills / Hooks / MCP / LSP |
+| 含められる要素 | 手順とその付随リソース | Agents / Skills / Commands / Hooks / MCP / LSP |
 | 導入方法 | `gh skill install`、`npx skills add`、手動配置 | `copilot plugin install`、`enabledPlugins` |
 | 向いている場面 | 1 つの作業手順を共有したい | チーム標準の拡張一式を配りたい |
 | 更新の追跡 | Skill 単位（tree SHA・pin） | Plugin 単位（Marketplace のバージョン） |
@@ -24,16 +24,19 @@ Plugin は、Custom Agents・Skills・Hooks・MCP サーバー設定・LSP サ�
 
 ## Plugin の構成
 
-Plugin の必須要素は、ディレクトリ直下の `plugin.json` マニフェストだけです。以下の要素は、必要なものだけを含められます。
+Plugin の必須要素は `plugin.json` マニフェストの `name` フィールドだけです。マニフェスト自体は `plugin.json`（ルート）のほか `.plugin/plugin.json` や `.github/plugin/plugin.json`、`.claude-plugin/plugin.json` でも認識されます。以下の要素は、必要なものだけを含められます。
 
 | 要素 | 配置場所 | 役割 |
 |------|---------|------|
-| マニフェスト | `plugin.json`（ルート・必須） | Plugin 名、説明、バージョン等のメタデータ |
+| マニフェスト | `plugin.json`（必須。`name` 以外は任意項目） | Plugin 名、説明、バージョン等のメタデータ |
 | Custom Agents | `agents/*.agent.md` | 専門家ペルソナの定義 |
 | Skills | `skills/<スキル名>/SKILL.md` | 関連リソース同梱の作業手順 |
+| Commands | `commands/` 配下 | スラッシュコマンドの定義 |
 | Hooks | ルートまたは `hooks/` の `hooks.json` | エージェントの動作に介入するイベントハンドラー |
 | MCP サーバー設定 | ルートの `.mcp.json` または `.github/mcp.json` | 外部サービス連携（Model Context Protocol） |
 | LSP サーバー設定 | ルートまたは `.github/` の `lsp.json` | 言語サーバー連携（Language Server Protocol） |
+
+> 各要素の配置場所は `plugin.json` の `agents` / `skills` / `commands` / `hooks` / `mcpServers` / `lspServers` フィールドで上書きできます。詳細なフィールド定義は [GitHub Copilot CLI plugin reference](https://docs.github.com/en/copilot/reference/copilot-cli-reference/cli-plugin-reference) を参照してください。
 
 ```text
 my-plugin/
@@ -85,10 +88,13 @@ Copilot CLI のセッション中は、スラッシュコマンドでも実行�
 /plugin install database-data-management@awesome-copilot
 ```
 
-### 3. 更新・削除する
+### 3. 更新・有効/無効・削除する
 
 ```powershell
-copilot plugin update database-data-management
+copilot plugin update database-data-management   # 個別に更新
+copilot plugin update --all                       # まとめて更新
+copilot plugin disable database-data-management   # 無効化（アンインストールせず一時停止）
+copilot plugin enable database-data-management    # 再度有効化
 copilot plugin uninstall database-data-management
 ```
 
@@ -96,14 +102,17 @@ copilot plugin uninstall database-data-management
 
 ```powershell
 copilot plugin marketplace add OWNER/REPO
+copilot plugin marketplace update MARKETPLACE-NAME   # カタログを再取得（alias: refresh）
 copilot plugin marketplace remove MARKETPLACE-NAME
 ```
 
-> **注意**: 追加時は Marketplace リポジトリの `OWNER/REPO` を、削除時は登録済み一覧に表示される **Marketplace 名** を指定します。Plugin がインストール済みの Marketplace は、`--force` を付けない限り削除されません（`--force` を付けると、その Marketplace 由来の Plugin も削除されます）。
+> **注意**: 追加時は Marketplace リポジトリの `OWNER/REPO`（ローカルパスや Git URL も可）を、更新・削除時は登録済み一覧に表示される **Marketplace 名**（`marketplace.json` の `name` フィールドの値）を指定します。Plugin がインストール済みの Marketplace は、`--force` を付けない限り削除されません（`--force` を付けると、その Marketplace 由来の Plugin も削除されます）。`copilot-plugins` と `awesome-copilot` は組み込みの既定 Marketplace のため削除できません。
 
-### インストール先
+### インストール先とバージョン固定
 
-Copilot CLI は Plugin を `~/.copilot/installed-plugins/<marketplace>/<plugin>/` に保存します。Marketplace を経由せず Git URL から直接インストールした Plugin は `_direct` に入ります。インストールは **開発者ごと・マシンごと** です。
+Copilot CLI は Plugin を `~/.copilot/installed-plugins/<marketplace>/<plugin-name>/` に保存します。Marketplace を経由せず Git URL やローカルパスから直接インストールした Plugin は `~/.copilot/installed-plugins/_direct/<source-id>/` に入ります。インストールは **開発者ごと・マシンごと** です。
+
+Marketplace の `marketplace.json` では、各 Plugin の `source` に GitHub リポジトリを指定でき、`ref`（タグ・ブランチ）に加えて **40 文字のフル commit SHA** を `sha` フィールドで指定すると、force-push やタグ・ブランチの移動に影響されない再現可能なインストールに固定できます。
 
 ---
 
@@ -124,7 +133,9 @@ Copilot CLI は Plugin を `~/.copilot/installed-plugins/<marketplace>/<plugin>/
 }
 ```
 
-リポジトリ側の設定ファイルをコミットしておけば、クローンした開発者が同じ Plugin 構成で作業を始められます。Enterprise では **managed settings** により、利用してよい Plugin を組織のポリシーとして強制できます（VS Code・Copilot CLI・Copilot アプリが対象）。
+リポジトリ側の設定ファイルをコミットしておけば、クローンした開発者が同じ Plugin 構成で作業を始められます。Copilot cloud agent（クラウド上のコーディングエージェント）は、この `enabledPlugins` を使う宣言的な方法のみに対応しています。既定で登録されていない Marketplace から導入したい場合は、同じ設定ファイルの `extraKnownMarketplaces` フィールドにも追加してください。
+
+Enterprise では **managed settings** により、利用してよい Plugin を組織のポリシーとして強制し、自動インストールする Plugin を指定することもできます（VS Code・Copilot CLI・Copilot アプリが対象）。
 
 ---
 
@@ -141,7 +152,7 @@ VS Code では **Agent plugins（Preview）** として提供され、「Agent P
 | Marketplace の実体 | Git リポジトリ（`marketplace.json`） | Git リポジトリ（`.claude-plugin/marketplace.json`） |
 | 登録コマンド | `copilot plugin marketplace add OWNER/REPO` | `/plugin marketplace add OWNER/REPO` |
 | インストール | `copilot plugin install NAME@MARKETPLACE` | `/plugin install NAME@MARKETPLACE` |
-| 含められる要素 | Agents / Skills / Hooks / MCP / LSP | Skills / Commands / Subagents / Hooks / MCP |
+| 含められる要素 | Agents / Skills / Commands / Hooks / MCP / LSP | Skills / Commands / Subagents / Hooks / MCP |
 | 既定の Marketplace | `copilot-plugins` / `awesome-copilot` | なし（利用者が追加） |
 | 組織での強制 | Enterprise managed settings | 設定ファイルの共有が中心 |
 

--- a/docs/trends.md
+++ b/docs/trends.md
@@ -1,6 +1,6 @@
 # Agent Skills・MCP・GUI 自動化の最新動向
 
-> **対象ツール**: ツール横断 ｜ **対象読者**: エンジニア ｜ **最終更新**: 2026-07-29
+> **対象ツール**: ツール横断 ｜ **対象読者**: エンジニア ｜ **最終更新**: 2026-08-01
 
 > Agent Skills は `SKILL.md` だけで完結する仕組みから、MCP、Web データ取得、デプロイ、Computer Use と組み合わさる実行基盤へ広がっています。本ページは、現在注目度の高いテーマを公式情報に基づいて整理する**常設ページ**です。内容は冒頭の「最終更新」日時点の情報で、動向が変わるたびに本ページを改訂します。
 
@@ -8,6 +8,7 @@
 
 | 日付 | 変更内容 |
 |------|---------|
+| 2026-08-01 | 「Skill の発見・配布・更新」を追加（`gh skill` / Agent Finder・ARD / Copilot Plugins） |
 | 2026-07-29 | 常設ページ化（旧タイトル「2026年7月版」）。ガイド全体の更新は [更新履歴（CHANGELOG）](../CHANGELOG.md) を参照 |
 | 2026-07-22 | 初版公開（Matt Pocock's Skills / Context7 / Firecrawl / Vercel / Record & Replay / Computer Use の6テーマ） |
 
@@ -24,6 +25,8 @@
 
 > `Versel` ではなく、正式な表記は **Vercel** です。
 
+> 「[7. Skill の発見・配布・更新](#7-skill-の発見配布更新)」は動画チャプター外の追補です。GitHub 公式のエコシステム側の動き（CLI・Registry・Plugin）を扱います。
+
 ---
 
 ## 全体像
@@ -36,6 +39,7 @@
 | Skill配布・実践 | Vercel / skills.sh | Skillの検索・導入、React等の公式知見 | Skill導入とWeb開発 |
 | 操作の記録 | Record & Replay | 実演から生成した再利用可能なSkill | 定型GUI業務 |
 | GUI実行 | Computer Use / Browser Use | 画面認識、クリック、入力、検証 | APIのないアプリやWeb画面 |
+| 発見・配布・更新 | `gh skill` / Agent Finder / Copilot Plugins | Skillを探す・固定する・組織へ配る仕組み | 導入後の運用と組織標準化 |
 
 ---
 
@@ -207,6 +211,150 @@ npx skills add vercel-labs/agent-skills
 
 ---
 
+## 7. Skill の発見・配布・更新
+
+> `gh skill` / Agent Finder・ARD / GitHub Copilot Plugins
+
+ここまでの 6 テーマが「どんな Skill があるか」だとすれば、本節は **「Skill をどう探し、安全に導入し、更新・固定・配布するか」** です。GitHub は 2026 年に、この運用面を埋める仕組みを 3 つ公式提供しました。
+
+| 仕組み | 役割 | 提供状況 |
+|--------|------|---------|
+| `gh skill` | GitHub CLI による Skill のライフサイクル管理（検索・確認・導入・更新・公開） | Public Preview（2026-04-16 提供開始、GitHub CLI v2.90.0 以降） |
+| Agent Finder / ARD | 必要になった時点で Skill・MCP・Agent・Tool を Registry から発見する | 提供中（2026-06-17 提供開始、全 Copilot プラン） |
+| Copilot Plugins | Agents・Skills・Hooks・MCP・LSP を 1 つの配布単位にまとめる | 提供中（Copilot CLI）／ VS Code は Preview |
+
+---
+
+### 7-1. `gh skill` — Skill のライフサイクル管理
+
+GitHub CLI から、複数の Agent Host を横断して Skill を管理できます。GitHub Copilot、Claude Code、Cursor、Codex、Gemini CLI など多数のエージェントに対応し、それぞれのホスト固有ディレクトリへ配置します。
+
+#### 探す・中身を見る
+
+```powershell
+gh skill search react
+gh skill preview github/awesome-copilot documentation-writer
+```
+
+`search` は GitHub Code Search API で公開リポジトリの `SKILL.md` を検索し、名前や説明にキーワードを含む Skill を返します。`preview` は **インストールせずに中身を確認する**ためのコマンドです。
+
+#### 導入する
+
+```powershell
+gh skill install github/awesome-copilot documentation-writer --agent copilot --scope user
+gh skill list
+```
+
+| フラグ | 意味 |
+|--------|------|
+| `--agent` | インストール先エージェントを指定（非対話実行時の既定は GitHub Copilot） |
+| `--scope` | `project`（現在の Git リポジトリ内）または `user`（ホームディレクトリ。既定は `project`） |
+| `--pin` | バージョンを固定し、以降の更新対象から外す |
+| `@<commit-sha>` | Skill 名の後ろに付けて、特定コミットを指定して導入 |
+
+#### 更新する
+
+```powershell
+gh skill update --all
+```
+
+インストール時に、取得元の **git tree SHA** が provenance メタデータとして記録されます。`update` はローカルとリモートの SHA を比較するため、バージョン表記だけが変わって中身が同じ場合は何もしません。
+
+#### 公開する
+
+```powershell
+gh skill publish --dry-run
+gh skill publish --fix
+```
+
+`publish` は Agent Skills 仕様への適合を検証します。`--dry-run` は公開せず検証のみ、`--fix` はメタデータの不備を自動修正します。あわせて、リポジトリ側の tag protection や immutable releases といったサプライチェーン設定も確認されます。
+
+#### 安全に使う
+
+- Skill は **GitHub による検証済みではありません**。プロンプトインジェクション、隠し指示、悪意あるスクリプトが含まれ得ます。
+- 導入前に `gh skill preview` で `SKILL.md` と `scripts/` を読み、想定外のネットワーク通信や作業ツリー外への書き込みがないか確認してください。
+- タグは後から差し替えられる可能性があるため、**コミット SHA での固定が最も安全**です。配布側で immutable releases を有効にすると、タグ指定でも内容が変わらなくなります。
+
+---
+
+### 7-2. Agent Finder / ARD — 必要な時に見つける
+
+Agent Finder は、自然言語で書いたタスクに応じて、Skill・MCP サーバー・Agent・Tool を Registry から検索し、候補をランキングして提示する仕組みです。**すべてを常時コンテキストへ詰め込まない**ため、Context Window の消費とツール選択の誤りを減らせます。
+
+| 特徴 | 内容 |
+|------|------|
+| 発見と接続は別 | 候補を提示するだけで、勝手に接続・インストールしない |
+| 対象リソース | Skills / MCP servers / Agents / Tools |
+| 組織制御 | Enterprise の managed settings で、発見・利用してよいリソースを限定できる |
+| 対応プラン | 全 GitHub Copilot プラン |
+
+#### ARD（Agentic Resource Discovery）
+
+Agent Finder は、Google・Microsoft・GitHub・Hugging Face・GoDaddy などが策定するオープン仕様 **ARD** の実装です。仕様は 2 つの構成要素からなります。
+
+| 構成要素 | 役割 |
+|---------|------|
+| Catalog | 提供元が自ドメインの `/.well-known/ai-catalog.json` に、公開するリソースを機械可読な形で掲載する |
+| Registry | 複数の Catalog を集約し、タスクの意図に基づく検索を提供する |
+
+Catalog には、Skill だけでなく OpenAPI で記述したツール、A2A エージェント、下位 Catalog への参照も含められます。オープン仕様であるため、社内向けの Private Registry を立てて、自組織の Skill カタログを同じ方式で運用することもできます。
+
+#### skills.sh・GitHub 検索との関係
+
+| 発見手段 | 対象範囲 | 実行主体 |
+|---------|---------|---------|
+| [skills.sh](https://skills.sh/) / `npx skills find` | 公開 Skill の Web ディレクトリ | 人が探す |
+| `gh skill search` | GitHub 上の公開 `SKILL.md` | 人が探す |
+| Agent Finder / ARD | Catalog を公開したリソース（公開・社内問わず） | エージェントがタスク実行中に探す |
+
+> 人が事前に選ぶのが前者 2 つ、エージェントが必要になった時点で探すのが Agent Finder、という違いです。
+
+---
+
+### 7-3. GitHub Copilot Plugins — まとめて配る
+
+Copilot Plugin は、`plugin.json` を持つディレクトリに Custom Agents・Skills・Hooks・MCP サーバー設定・LSP サーバー設定をまとめた配布単位です。Marketplace（`marketplace.json` を置いた Git リポジトリ）から導入します。
+
+```powershell
+copilot plugin marketplace list
+copilot plugin marketplace browse awesome-copilot
+copilot plugin install database-data-management@awesome-copilot
+copilot plugin list
+copilot plugin update database-data-management
+```
+
+Copilot CLI には `copilot-plugins`（GitHub 公式コレクション）と `awesome-copilot` が既定で登録されています。リポジトリの `.github/copilot/settings.json` に `enabledPlugins` を書けば、そのリポジトリの開発者全員へ同じ構成を適用できます。
+
+**→ 構成・`enabledPlugins`・Claude Code Plugin との比較は [GitHub Copilot Plugins](copilot/plugins.md) を参照**
+
+---
+
+### 3 つの仕組みの比較
+
+| 観点 | `npx skills` | `gh skill` | Copilot Plugin |
+|------|-------------|-----------|----------------|
+| 主用途 | Skill の検索・導入 | Skill のライフサイクル管理 | 複数拡張の一括配布 |
+| 配布単位 | Skill | Skill | Plugin |
+| 更新追跡 | CLI 依存 | provenance（git tree SHA） | Marketplace のバージョン |
+| バージョン固定 | — | `--pin` / コミット SHA 指定 | Marketplace のバージョン |
+| 対応 Host | 複数エージェント | 複数エージェント | 主に Copilot CLI / VS Code |
+| 含められる要素 | Skills | Skills | Skills / Agents / Hooks / MCP / LSP |
+| サプライチェーン対策 | 配布元の確認 | `preview` / pin / immutable releases | Marketplace と Enterprise ポリシー |
+| 提供元 | Vercel（コミュニティ） | GitHub（公式） | GitHub（公式） |
+
+### 使い分けの目安
+
+| やりたいこと | 選ぶもの |
+|-------------|---------|
+| Skill を探して試す | `npx skills find` / `gh skill search` |
+| 導入前に中身を確認する | `gh skill preview` |
+| バージョンを固定して事故を防ぐ | `gh skill install ...@<commit-sha>` または `--pin` |
+| 自作 Skill を公開・配布する | `gh skill publish` |
+| チーム標準の拡張一式を配る | Copilot Plugin + `enabledPlugins` |
+| 組織で使えるリソースを制限する | Enterprise managed settings（Agent Finder / Plugins） |
+
+---
+
 ## 使い分け
 
 | やりたいこと | 第一候補 |
@@ -217,6 +365,9 @@ npx skills add vercel-labs/agent-skills
 | 要件整理からTDD・レビューまでの開発手順を改善したい | Matt Pocock's Skills |
 | 毎回同じGUI操作をSkill化したい | Record & Replay |
 | APIのないデスクトップ／Web画面を直接操作したい | Computer Use / Browser Use |
+| Skillを検索・固定・公開したい | `gh skill` |
+| チームや組織へ拡張一式を配布したい | Copilot Plugins |
+| 必要な時だけツールを見つけさせたい | Agent Finder / ARD |
 
 ---
 
@@ -229,6 +380,17 @@ npx skills add vercel-labs/agent-skills
 - [vercel-labs/agent-skills](https://github.com/vercel-labs/agent-skills)
 - [OpenAI Record & Replay](https://learn.chatgpt.com/docs/extend/record-and-replay)
 - [OpenAI Computer Use](https://learn.chatgpt.com/docs/computer-use)
+
+### Skill の発見・配布・更新（本ページ 7 節）
+
+- [Manage agent skills with GitHub CLI](https://github.blog/changelog/2026-04-16-manage-agent-skills-with-github-cli/) — `gh skill` の提供開始（公式）
+- [gh skill マニュアル](https://cli.github.com/manual/gh_skill) — サブコマンドとフラグ（公式）
+- [Adding agent skills for GitHub Copilot](https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/customize-cloud-agent/add-skills) — Copilot への Skill 追加（公式）
+- [Agent finder for GitHub Copilot now available](https://github.blog/changelog/2026-06-17-agent-finder-for-github-copilot-now-available/) — Agent Finder の提供開始（公式）
+- [ARD Specification](https://agenticresourcediscovery.org/spec/) — Agentic Resource Discovery 仕様（公式）
+- [About GitHub Copilot plugins](https://docs.github.com/en/copilot/concepts/agents/about-plugins) — Plugin の概念と構成（公式）
+- [Finding and installing plugins for GitHub Copilot CLI](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/plugins-finding-installing) — Plugin の導入手順（公式）
+- [GitHub Copilot Plugins 日本語解説](copilot/plugins.md) — 本ガイド内の詳細ページ
 
 ---
 

--- a/docs/trends.md
+++ b/docs/trends.md
@@ -220,37 +220,39 @@ npx skills add vercel-labs/agent-skills
 | 仕組み | 役割 | 提供状況 |
 |--------|------|---------|
 | `gh skill` | GitHub CLI による Skill のライフサイクル管理（検索・確認・導入・更新・公開） | Public Preview（2026-04-16 提供開始、GitHub CLI v2.90.0 以降） |
-| Agent Finder / ARD | 必要になった時点で Skill・MCP・Agent・Tool を Registry から発見する | 提供中（2026-06-17 提供開始、全 Copilot プラン） |
+| Agent Finder / ARD | 必要になった時点で MCP サーバー・Skill・Canvas・Agent・Tool を Registry から発見する | 提供中（2026-06-17 提供開始、全 Copilot プラン） |
 | Copilot Plugins | Agents・Skills・Hooks・MCP・LSP を 1 つの配布単位にまとめる | 提供中（Copilot CLI）／ VS Code は Preview |
 
 ---
 
 ### 7-1. `gh skill` — Skill のライフサイクル管理
 
-GitHub CLI から、複数の Agent Host を横断して Skill を管理できます。GitHub Copilot、Claude Code、Cursor、Codex、Gemini CLI など多数のエージェントに対応し、それぞれのホスト固有ディレクトリへ配置します。
+GitHub CLI v2.90.0 以降で利用できます。GitHub Copilot、Claude Code、Cursor、Codex、Gemini CLI など多数の Agent Host に対応し、`--agent` で指定したホスト固有のディレクトリへ Skill を配置します（`gh skill install --help` で全対応ホストを確認できます）。
 
 #### 探す・中身を見る
 
 ```powershell
-gh skill search react
+gh skill search terraform
 gh skill preview github/awesome-copilot documentation-writer
 ```
 
-`search` は GitHub Code Search API で公開リポジトリの `SKILL.md` を検索し、名前や説明にキーワードを含む Skill を返します。`preview` は **インストールせずに中身を確認する**ためのコマンドです。
+`search` は GitHub Code Search API で公開リポジトリの `SKILL.md` を検索し、名前や説明がクエリに一致する Skill を関連度順に返します（`--owner` で検索対象を特定ユーザー／組織に絞り込み可能）。`preview` は **インストールせずに `SKILL.md` の内容をターミナルで確認する**ためのコマンドです。
 
 #### 導入する
 
 ```powershell
-gh skill install github/awesome-copilot documentation-writer --agent copilot --scope user
+gh skill install github/awesome-copilot documentation-writer --agent claude-code --scope user
 gh skill list
 ```
 
 | フラグ | 意味 |
 |--------|------|
-| `--agent` | インストール先エージェントを指定（非対話実行時の既定は GitHub Copilot） |
-| `--scope` | `project`（現在の Git リポジトリ内）または `user`（ホームディレクトリ。既定は `project`） |
-| `--pin` | バージョンを固定し、以降の更新対象から外す |
-| `@<commit-sha>` | Skill 名の後ろに付けて、特定コミットを指定して導入 |
+| `--agent` | インストール先エージェントを指定する値。例: `github-copilot`（非対話実行時の既定）、`claude-code`、`cursor`、`codex`、`gemini-cli` 等 |
+| `--scope` | `project`（現在の Git リポジトリ内。既定）または `user`（ホームディレクトリ、どこからでも利用可） |
+| `--pin <string>` | 指定した git タグまたはコミット SHA に固定し、以降 `update` の対象から外す |
+| `@<VERSION>` | Skill 名の後ろに付けて、特定のタグ・ブランチ・コミット SHA を指定して導入・プレビュー |
+
+バージョンを指定しない場合、`install` はリポジトリの最新タグ付きリリース、無ければデフォルトブランチの HEAD を解決します。
 
 #### 更新する
 
@@ -258,7 +260,7 @@ gh skill list
 gh skill update --all
 ```
 
-インストール時に、取得元の **git tree SHA** が provenance メタデータとして記録されます。`update` はローカルとリモートの SHA を比較するため、バージョン表記だけが変わって中身が同じ場合は何もしません。
+`install` 時に、取得元リポジトリ・ref・**git tree SHA** が Skill 自身の `SKILL.md` frontmatter へ書き込まれます。この情報は Skill ファイルに同梱されるため、コピー・移動しても追跡が失われません。`update` はローカルとリモートの tree SHA を比較して実際に内容が変わった Skill だけを更新し、`--pin` した Skill は通知のみでスキップします（対象に含めるには `--unpin`）。
 
 #### 公開する
 
@@ -267,7 +269,7 @@ gh skill publish --dry-run
 gh skill publish --fix
 ```
 
-`publish` は Agent Skills 仕様への適合を検証します。`--dry-run` は公開せず検証のみ、`--fix` はメタデータの不備を自動修正します。あわせて、リポジトリ側の tag protection や immutable releases といったサプライチェーン設定も確認されます。
+`publish` は Skill 名の命名規則やディレクトリ名との一致、必須 frontmatter（`name` / `description`）の有無など、[Agent Skills 仕様](https://agentskills.io/specification) への適合を検証します。`--dry-run` は公開せず検証のみ、`--fix` はインストール時に混入したメタデータ（`metadata.github-*`）を公開せずに取り除きます。検証に通ると、`tag protection` ・ secret scanning ・ code scanning といったリポジトリ設定の確認と、**immutable releases**（公開後は管理者でもリリース内容を変更できなくする設定）の有効化を対話的に案内します。
 
 #### 安全に使う
 
@@ -279,12 +281,12 @@ gh skill publish --fix
 
 ### 7-2. Agent Finder / ARD — 必要な時に見つける
 
-Agent Finder は、自然言語で書いたタスクに応じて、Skill・MCP サーバー・Agent・Tool を Registry から検索し、候補をランキングして提示する仕組みです。**すべてを常時コンテキストへ詰め込まない**ため、Context Window の消費とツール選択の誤りを減らせます。
+Agent Finder は、自然言語で書いたタスクに応じて、MCP サーバー・Skill・Canvas・Agent・Tool を Registry（インデックス）から検索し、候補をランキングして提示する仕組みです。**すべてを常時コンテキストへ詰め込まない**ため、Context Window の消費とツール選択の誤りを減らせます。
 
 | 特徴 | 内容 |
 |------|------|
 | 発見と接続は別 | 候補を提示するだけで、勝手に接続・インストールしない |
-| 対象リソース | Skills / MCP servers / Agents / Tools |
+| 対象リソース | MCP servers / Skills / Canvases / Agents / Tools |
 | 組織制御 | Enterprise の managed settings で、発見・利用してよいリソースを限定できる |
 | 対応プラン | 全 GitHub Copilot プラン |
 
@@ -348,7 +350,7 @@ Copilot CLI には `copilot-plugins`（GitHub 公式コレクション）と `aw
 |-------------|---------|
 | Skill を探して試す | `npx skills find` / `gh skill search` |
 | 導入前に中身を確認する | `gh skill preview` |
-| バージョンを固定して事故を防ぐ | `gh skill install ...@<commit-sha>` または `--pin` |
+| バージョンを固定して事故を防ぐ | `gh skill install ...@<コミットSHA>` または `--pin <コミットSHA>` |
 | 自作 Skill を公開・配布する | `gh skill publish` |
 | チーム標準の拡張一式を配る | Copilot Plugin + `enabledPlugins` |
 | 組織で使えるリソースを制限する | Enterprise managed settings（Agent Finder / Plugins） |

--- a/docs/trends.md
+++ b/docs/trends.md
@@ -338,7 +338,7 @@ Copilot CLI には `copilot-plugins`（GitHub 公式コレクション）と `aw
 | 主用途 | Skill の検索・導入 | Skill のライフサイクル管理 | 複数拡張の一括配布 |
 | 配布単位 | Skill | Skill | Plugin |
 | 更新追跡 | CLI 依存 | provenance（git tree SHA） | Marketplace のバージョン |
-| バージョン固定 | — | `--pin` / コミット SHA 指定 | Marketplace のバージョン |
+| バージョン固定 | — | `--pin` / コミット SHA 指定 | Marketplace のバージョン / `source.sha`（commit SHA） |
 | 対応 Host | 複数エージェント | 複数エージェント | 主に Copilot CLI / VS Code |
 | 含められる要素 | Skills | Skills | Skills / Agents / Hooks / MCP / LSP |
 | サプライチェーン対策 | 配布元の確認 | `preview` / pin / immutable releases | Marketplace と Enterprise ポリシー |


### PR DESCRIPTION
## Summary

Closes #84

- `docs/trends.md` に「7. Skill の発見・配布・更新」を新設し、`gh skill`（search / preview / install / update / publish）、Agent Finder・ARD（Agentic Resource Discovery）、GitHub Copilot Plugins を PowerShell 例付きで解説
- `npx skills` / `gh skill` / Copilot Plugin の比較表と、目的別の使い分け表を追加
- `docs/copilot/plugins.md` を新設。Plugin の構成（`plugin.json` / agents / skills / commands / hooks / MCP / LSP）、Marketplace の導入・更新・有効/無効化、`enabledPlugins` / `extraKnownMarketplaces` による標準化、commit SHA でのバージョン固定、Claude Code Plugin Marketplace との比較を解説
- `docs/copilot/README.md` の「カスタマイズの種類」に Plugins を追加
- `README.md` の目的別ナビ・ドキュメント一覧・用語対照表を更新
- `CHANGELOG.md` / `CONTRIBUTING.md` を更新

## 検証について

初回コミット後、このセッションのネットワークポリシーを Trusted からカスタム（`docs.github.com` / `github.blog` / `cli.github.com` / `agenticresourcediscovery.org` を許可）に変更してもらい、`docs.github.com`・`cli.github.com`・`github.blog`・ARD 仕様サイトの一次情報を取得して記述を裏取りしました。この過程で以下を修正しています。

- `gh skill install` の `--agent` 指定例の誤り（`copilot` → 正しくは `github-copilot`）
- `--pin` / `@VERSION` によるバージョン固定の説明を実際の仕様に合わせて精緻化
- `gh skill update` / `publish` の挙動（tree SHA の記録場所、`--fix` が取り除くメタデータ、`publish` が確認する tag protection・secret scanning・code scanning）
- Agent Finder が発見する対象に Canvases が抜けていたため追加
- Copilot Plugins に `commands` コンポーネント、`enable`/`disable`、`marketplace update`、`marketplace.json` の `source.sha` によるバージョン固定、cloud agent 向け `extraKnownMarketplaces` を追記

## Test plan

- [x] 内部リンク・見出しアンカーをスクリプトで検証（欠落なし）
- [x] `gh skill` / Agent Finder・ARD / Copilot Plugins の記述を公式ドキュメント原文と突き合わせて確認
- [ ] レビューでの日本語表現・表記ゆれの確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019KaH9hCWq2u9VLRH3DVSSV

---
_Generated by [Claude Code](https://claude.ai/code/session_019KaH9hCWq2u9VLRH3DVSSV)_